### PR TITLE
Make install target compatible with package manager install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ HEADERS       = $(SRCPATH)msiklm.h
 SOURCES       = $(SRCPATH)main.c $(SRCPATH)msiklm.c
 OBJECTS       = main.o msiklm.o
 TARGET        = msiklm
-INSTALLTARGET = /usr/local/bin/$(TARGET)
+INSTALLPREFIX = /usr/local/bin
 
 
 ####### Build rules
@@ -38,10 +38,8 @@ delete: clean
 	-$(DEL_FILE) $(TARGET)
 
 install:
-	@if [ -f $(TARGET) ]; then\
-	    sudo mv -v $(TARGET) $(INSTALLTARGET);\
-	    sudo chmod 744 $(INSTALLTARGET);\
-	fi
+	@cp -v $(TARGET) $(INSTALLPREFIX)/$(TARGET)
+	@chmod 755 $(INSTALLPREFIX)/$(TARGET)
 
 ####### Compile
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-1. GENERAL
+# GENERAL
 
 The MSI Keyboard Light Manager (MSIKLM) is an easy-to-use tool that allows to configure the
 SteelSeries keyboards of MSI gaming notebooks with Linux in almost the same way as the
 SteelSeries Engine can do using Windows.
 
 
-2. INSTALLATION & REQUIREMENTS
+# INSTALLATION & REQUIREMENTS
+## Manual installation
 
 I tried to keep the external dependencies to a minimum level, however there are some unavoidable
 ones. These are:
 
-    GCC     - the C compliler
-    make    - the main build tool of the Linux world
-    LIBUSB  - MSIKLM needs to communicate with the keyboard, for this LIBUSB is required
+ * GCC     - the C compliler
+ * make    - the main build tool of the Linux world
+ * LIBUSB  - MSIKLM needs to communicate with the keyboard, for this LIBUSB is required
 
 Besides there are no others, no Qt, no Java, not even a C++ compiler is required. To install the
 program, there is an installation script 'install.sh' which can be run by opening the respective
@@ -28,27 +29,44 @@ as well which will most certainly will work on most Linux distributions. This sc
 following steps, if you do not want to use the installation script for some reason, you can use
 the manual commands instead:
 
-    1. installation of the dependencies
-       (manual command: sudo apt-get install -y gcc make libhidapi-dev)
+ * installation of the dependencies
+   ```
+   sudo apt-get install -y gcc make libhidapi-dev
+   ```
 
-    2. compiling of MSIKLM
-       (manual command: make)
+ * compiling of MSIKLM
+   ```
+   make
+   ```
 
-    3. clean up
-       (manual command: make clean)
+ * clean up
+   ```
+   make clean
+   ```
 
-    4. copy the built program to '/usr/local/bin/msiklm' and set its permssions
-       (manual commands: sudo mv -fv msiklm /usr/local/bin/msiklm and sudo chmod 744 /usr/local/bin/msiklm)
+ * copy the built program to '/usr/local/bin/msiklm' and set its permissions
+   ```
+   sudo mv -fv msiklm /usr/local/bin/msiklm
+   sudo chmod 744 /usr/local/bin/msiklm
+   ```
 
-    5. test the connection
-       (manual command: sudo msiklm test)
+ * test the connection
+   ```
+   sudo msiklm test
+   ```
 
 Whenever MSIKLM is used, it should always be run as root because otherwise, the communication with
 the keyboard is not possible, hence always use the sudo prefix (only 'msiklm help' will work as
 non-root).
 
+## Distribution package
 
-3. USABILITY
+Currently, the only linux distribution providing an install method is Archlinux, via the AUR repository
+
+ * Archlinux : https://aur.archlinux.org/packages/msiklm-git/
+
+
+# USABILITY
 
 MSIKLM is a pure command line application, however its keyboard illumination control functionality
 is encapsulated such that it could easily be integrated into a graphical user interface. However,
@@ -56,14 +74,14 @@ I neither wrote one for it nor I plan to do so. It is quite easy to use, and her
 it. It always has to be called with at least one argument, i.e. running it without one will result
 in an error. Here is an overview over the valid commands:
 
-command                                               | valid arguments                                                                              | example
-============================================================================================================================================================================================
-sudo msiklm <color>                                   | none, off (equivalent to none), red, orange, yellow, green, sky, blue, purple, white         | sudo msiklm green
-sudo msiklm <color_left>,<color_middle>,<color_right> | same as single color (important: no space between the colors!)                               | sudo msiklm green,blue,red
-sudo msiklm <mode>                                    | normal, gaming, breathe, demo, wave                                                          | sudo msiklm wave
-sudo msiklm <color> <brightness>                      | color either one or three values (comma-separated), brightness can be off, low, medium, high | sudo msiklm green high
-sudo msiklm <color> <mode>                            | same as above                                                                                | sudo msiklm green,blue,red wave
-sudo msiklm <color> <brightness> <mode>               | same as above                                                                                | sudo msiklm green,blue,red high wave
+|command                                               | valid arguments                                                                              | example                              |
+|------------------------------------------------------|----------------------------------------------------------------------------------------------|--------------------------------------|
+|sudo msiklm <color>                                   | none, off (equivalent to none), red, orange, yellow, green, sky, blue, purple, white         | sudo msiklm green                    |
+|sudo msiklm <color_left>,<color_middle>,<color_right> | same as single color (important: no space between the colors!)                               | sudo msiklm green,blue,red           |
+|sudo msiklm <mode>                                    | normal, gaming, breathe, demo, wave                                                          | sudo msiklm wave                     |
+|sudo msiklm <color> <brightness>                      | color either one or three values (comma-separated), brightness can be off, low, medium, high | sudo msiklm green high               |
+|sudo msiklm <color> <mode>                            | same as above                                                                                | sudo msiklm green,blue,red wave      |
+|sudo msiklm <color> <brightness> <mode>               | same as above                                                                                | sudo msiklm green,blue,red high wave |
 
 Additionally, there are three extra commands that might be useful if something does not work:
     msiklm help         -> shows the program's help
@@ -71,7 +89,7 @@ Additionally, there are three extra commands that might be useful if something d
     sudo msiklm list    -> lists all found hid devices, this might be helpful if your keyboard is not detected by MSIKLM
 
 
-4. AUTOSTART
+# AUTOSTART
 
 An important additional feature is the optional autostart functionality since the keyboard will
 reset itself to its default color configuration whenever you reboot it or resume from standby.
@@ -123,7 +141,7 @@ which will undo the modifications of /etc/rc.local as well as removing the creat
 If you manually moved the wakeup script, it will not be automatically removed.
 
 
-5. UNINSTALLATION
+# UNINSTALLATION
 
 MSIKLM also comes with an uninstallation script uninstall.sh which will remove the program file
 /usr/local/bin/msiklm as well as running ./autostart --disable, i.e. it disables the autostart and
@@ -132,7 +150,7 @@ removes created wakeup scripts. If you want to use it, simply run:
     ./uninstall.sh
 
 
-6. DEVELOPPER INFORMATION
+# DEVELOPPER INFORMATION
 
 The source code is splitted into three files: The main application (main.c) that converts the
 input as well as a small library that contains the main features (msiklm.h and msiklm.c). It


### PR DESCRIPTION
...And also simplify the process : 
I believe `sudo` was useless as you already call `sudo make install`.
And i also think the file presence check isn't needed, if anything, it'll make it harder for an user to troubleshoot his installation.

The reason why I changed `INSTALLTARGET` to `INSTALLPREFIX` is so that make install can be called as follows
`make INSTALLPREFIX=/usr/bin install`
when installed via a package manager