### PR TITLE
Fixed heap corruption, extra byte for NULL termination symbol

### DIFF
--- a/src/msiklm.c
+++ b/src/msiklm.c
@@ -121,7 +121,7 @@ int parse_color(const char* color_str, struct color* result)
 
             case '[':
                 {
-                    char* color_rgb = malloc(strlen(color_str)-1);
+                    char* color_rgb = malloc(sizeof(char) * strlen(color_str));
                     strcpy(color_rgb, &color_str[1]); //copy the string and skip the '[' sign
 
                     char* saved_ptr = NULL;


### PR DESCRIPTION
As stated [here](http://stackoverflow.com/questions/3695263/how-to-allocate-the-array-before-calling-strcpy/3695271#3695271) in general case we need to allocate ``N+1`` bytes for string of length ``N`` in order to copy over ``NULL`` termination byte, otherwise we'll corrupt heap memory with ``strcpy`` call.

So, in this case we need to allocate ``strlen(color_str)`` bytes, as we're omitting first symbol.

Testcase which I used to test if I'm right about this:
```c
#include <stdio.h>
#include <string.h>
#include <stdlib.h>

int main()
{
	const char* test = "[255;255;255]";

	printf("string length: %i\n", (int)strlen(test));

	char* test_dest = malloc(strlen(test) + 1);

	test_dest[strlen(test)] = 0xFF;

	printf("value before strcpy: %hhx\n", test_dest[strlen(test)]);

	strcpy(test_dest, test);

	printf("value after strcpy: %hhx\n", test_dest[strlen(test)]);

	free(test_dest);

	return 0;
}

```