### PR TITLE
Allow color and gaming mode to be set at the same time

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -352,9 +352,15 @@ int main(int argc, char** argv)
 
         if (dev != NULL)
         {
-            for (int i=0; i<num_regions && ret == 0; ++i)
-                if (set_color(dev, colors[i], i+1, br) <= 0)
-                    ret = -1;
+            if (num_regions > 0)
+            {
+                if (md == gaming)
+                    num_regions=1;
+
+                for (int i=0; i<num_regions && ret == 0; ++i)
+                    if (set_color(dev, colors[i], i+1, br) <= 0)
+                        ret = -1;
+            }
 
             if (ret == 0 && set_mode(dev, md) <= 0)
                 ret = -1;


### PR DESCRIPTION
Color and gaming mode do not seem to be able to be set at the same time. I have a 3 zone MSI GE62VR 7RF and when I try 'msiklm green gaming', for example, all 3 zones are green. This change fixes the problem for me and I have tested it with the other options.