### PR TITLE
Update install.sh to support Fedora, Centos/Redhat 7/8

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,12 @@ sleep 2
 if (sudo apt install -y gcc make libhidapi-dev); then
     echo "Dependencies successfully installed"
     sleep 2
+elif (sudo dnf install -y gcc make hidapi-devel); then
+    echo "Dependencies successfully installed"
+    sleep 2
+elif (sudo yum install -y gcc make hidapi-devel); then
+    echo "Dependencies successfully installed"
+    sleep 2
 elif (sudo pacman -S --noconfirm gcc make hidapi); then
     echo "Dependencies successfully installed"
     sleep 2


### PR DESCRIPTION
Adding changes that will enable Fedora, Centos and Redhat users to run install.sh